### PR TITLE
Fix header Markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ m32u4       B 5	    B 4	    B 7	    Leonardo        9       8         11
 AT90USB1286	B 5	    F 7	    B 4	    --	            --	    --	      --
 ```
 
-##Connections
+## Connections
 
 SYNC is on OCR1A and AUDIO is on OCR2A (except on the Arduino Leonardo, where AUDIO is on OCR0A)
 
@@ -26,7 +26,7 @@ There are some timing issues with the m1284p, may be related to sanguino core.
 On NG, Decimila, UNO and Nano the sync is pin 9, video on 7 and audio on 11. On Mega2560	sync is pin 11, video is on A7(D29)	and audio is on pin 10.
 
 
-##Examples
+## Examples
 
 https://youtu.be/MEg_V4YZDh0
 


### PR DESCRIPTION
GitHub's Markdown interpreter was recently changed to strictly enforce the [GFM spec](https://github.github.com/gfm/), which requires a delimiting space in header Markdown. This has caused some Markdown to no longer display as originally intended.

More information:
https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown
https://github.com/github/markup/issues/1013